### PR TITLE
Render parameter properties as a formatted list rather then a table

### DIFF
--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -671,10 +671,10 @@ Doc.prototype = {
             dom.html(' <p><em>(default: ' + param.default + ')</em></p>');
           }
           if (param.properties) {
-            dom.html('<br/>Valid values:-')
+            dom.html('<br/>Valid values:-');
             dom.html('<ul>');
 
-            for(var pr = 0; pr < param.properties.length; pr++){
+            for (var pr = 0; pr < param.properties.length; pr++) {
               var prop = param.properties[pr];
               
               dom.html('<li>');
@@ -688,12 +688,12 @@ Doc.prototype = {
 
               dom.html('<div class="tk-rgrid-u-md-21-24 tk-rgrid-u-1 property-description">');
               dom.html(prop.description);
-              if(prop.default) {
+              if (prop.default) {
                 dom.html(' <strong>(default)</strong>');
               }
               dom.html('</div>');
 
-              dom.html('</div>')
+              dom.html('</div>');
               dom.html('</li>');
             }
 
@@ -701,7 +701,7 @@ Doc.prototype = {
           }
           dom.html('</td>');
           dom.html('</tr>');
-        };
+        }
       }
       dom.html('</tbody>');
       dom.html('</table>');

--- a/src/ngdoc.js
+++ b/src/ngdoc.js
@@ -671,19 +671,33 @@ Doc.prototype = {
             dom.html(' <p><em>(default: ' + param.default + ')</em></p>');
           }
           if (param.properties) {
-//            dom.html('<table class="variables-matrix table table-bordered table-striped">');
-            dom.html('<table>');
-            dom.html('<thead>');
-            dom.html('<tr>');
-            dom.html('<th>Property</th>');
-            dom.html('<th>Type</th>');
-            dom.html('<th>Details</th>');
-            dom.html('</tr>');
-            dom.html('</thead>');
-            dom.html('<tbody>');
-            processParams(param.properties);
-            dom.html('</tbody>');
-            dom.html('</table>');
+            dom.html('<br/>Valid values:-')
+            dom.html('<ul>');
+
+            for(var pr = 0; pr < param.properties.length; pr++){
+              var prop = param.properties[pr];
+              
+              dom.html('<li>');
+              dom.html('<div class="tk-rgrid-g">');
+
+              dom.html('<div class="tk-rgrid-u-md-3-24 tk-rgrid-u-1">');
+              dom.html('<strong>');
+              dom.html(prop.name);
+              dom.html('</strong>');
+              dom.html('</div>');
+
+              dom.html('<div class="tk-rgrid-u-md-21-24 tk-rgrid-u-1 property-description">');
+              dom.html(prop.description);
+              if(prop.default) {
+                dom.html(' <strong>(default)</strong>');
+              }
+              dom.html('</div>');
+
+              dom.html('</div>')
+              dom.html('</li>');
+            }
+
+            dom.html('</ul>');
           }
           dom.html('</td>');
           dom.html('</tr>');


### PR DESCRIPTION
Format within the documentation comments
```
 * @param {string=}             wildcard                    Whether to add a wildcard to the search query.
 * @param {string=}             wildcard.left               `*searchQuery`
 * @param {string=}             [wildcard.right=right]      `searchQuery*`
 * @param {string=}             wildcard.both               `*searchQuery*`
 * @param {string=}             wildcard.none               `searchQuery`
```

Example
![screen shot 2018-04-16 at 09 54 28](https://user-images.githubusercontent.com/4819071/38799383-4c46e172-415c-11e8-9a2b-7a76536c7542.png)
