### PR TITLE
Strip empty lines from generated docs

### DIFF
--- a/tasks/grunt-ngdocs.js
+++ b/tasks/grunt-ngdocs.js
@@ -108,7 +108,9 @@ module.exports = function (grunt) {
             // this hack is here because on OSX angular.module and angular.Module map to the same file.
             var id = doc.id.replace('angular.Module', 'angular.IModule').replace(':', '.'),
                 file = path.resolve(options.dest, 'partials', doc.section, id + '.html');
-            grunt.file.write(file, doc.html());
+            var html = doc.html();
+            html = html.replace(/^\s*[\r\n]/gm, '');
+            grunt.file.write(file, html);
         });
 
         // KW - Create directives.json - START


### PR DESCRIPTION
Few lines of code in the task that generates the docs to remove empty lines.
Based on the following
http://jsfiddle.net/frankdavid/4XTv8/1/

I've tested this by running Fusion Docs locally and testing chart:display page which renders. 

However a different issue stops the page working correctly. Fusion docs uses underscore, we use lodash. Underscore doesn't have `_.get` based on the error messages.